### PR TITLE
DP-100 Setup default admin user

### DIFF
--- a/auth/serverless.yml
+++ b/auth/serverless.yml
@@ -122,6 +122,8 @@ resources:
             Value: "{}"
           - Name: "custom:access_group"
             Value: "admin"
+          - Name: "email_verified"
+            Value: "true"
         UserPoolId: { Ref: UserPool }
 
     # Attach the root user to the admin group by default.

--- a/auth/serverless.yml
+++ b/auth/serverless.yml
@@ -38,7 +38,11 @@ resources:
             AttributeDataType: "String"
             Mutable: true
             Required: true
-          - Name: "name"
+          - Name: "given_name"
+            AttributeDataType: "String"
+            Mutable: true
+            Required: true
+          - Name: "family_name"
             AttributeDataType: "String"
             Mutable: true
             Required: true
@@ -71,7 +75,8 @@ resources:
           - "ALLOW_REFRESH_TOKEN_AUTH"
         WriteAttributes:
           - "address"
-          - "name"
+          - "given_name"
+          - "family_name"
           - "email"
 
     # User groups.
@@ -115,7 +120,9 @@ resources:
         UserAttributes:
           - Name: "email"
             Value: ${param:rootEmail}
-          - Name: "name"
+          - Name: "given_name"
+            Value: "Admin"
+          - Name: "family_name"
             Value: "MapLight"
           - Name: "address"
             Value: "{}"

--- a/auth/serverless.yml
+++ b/auth/serverless.yml
@@ -112,7 +112,6 @@ resources:
       Properties:
         DesiredDeliveryMediums:
           - "EMAIL"
-        Username: "root"
         UserAttributes:
           - Name: "email"
             Value: ${param:rootEmail}

--- a/auth/serverless.yml
+++ b/auth/serverless.yml
@@ -103,6 +103,37 @@ resources:
         Precedence: 0
         UserPoolId: { Ref: UserPool }
 
+    # Default admin user that is to be created on site deployment.
+    # Should be granted the highest access level and allow creating other
+    # admin users after login, since admin/staff users should only be
+    # able to be created through invitation
+    RootUser:
+      Type: "AWS::Cognito::UserPoolUser"
+      Properties:
+        DesiredDeliveryMediums:
+          - "EMAIL"
+        Username: "root"
+        UserAttributes:
+          - Name: "email"
+            Value: ${param:rootEmail}
+          - Name: "name"
+            Value: "MapLight"
+          - Name: "address"
+            Value: "{}"
+          - Name: "custom:access_group"
+            Value: "admin"
+        UserPoolId: { Ref: UserPool }
+
+    # Attach the root user to the admin group by default.
+    # We can likely rely on the post-sign up lambda for this once
+    # that's implemented, but let's do it explicitly for now
+    RootUserGroupMembership:
+      Type: "AWS::Cognito::UserPoolUserToGroupAttachment"
+      Properties:
+        GroupName: { Ref: AdminUserGroup }
+        UserPoolId: { Ref: UserPool }
+        Username: { Ref: RootUser }
+
     # The identity pool that will be used to link roles to
     # entities. Particularly for allowing unauthenticated access
     # to parts of the API. 


### PR DESCRIPTION
Define the default admin user that will be created along with a new deployment of the app, allowing the creation of new admin users and site management. Add it to the admin user group by default.