### PR TITLE
DP-188 Add API support for editing a Candidate petition

### DIFF
--- a/api/schema/petition/candidate.graphql
+++ b/api/schema/petition/candidate.graphql
@@ -1,6 +1,9 @@
 type CandidatePetition implements Petition @aws_iam @aws_cognito_user_pools {
     PK: ID!
+
     createdAt: AWSDateTime!
+    updatedAt: AWSDateTime!
+    version: Int!
 
     type: PetitionType!
     status: PetitionStatus!
@@ -26,4 +29,14 @@ input CandidatePetitionInput {
     address: AddressInput!
     party: ID!
     office: ID!
+}
+
+input EditCandidatePetitionInput {
+    PK: ID!
+
+    address: AddressInput
+    party: ID
+    office: ID
+
+    expectedVersion: Int!
 }

--- a/api/schema/petition/common.graphql
+++ b/api/schema/petition/common.graphql
@@ -24,7 +24,10 @@ type SignatureSummary @aws_iam @aws_cognito_user_pools {
 
 interface Petition {
     PK: ID!
+
     createdAt: AWSDateTime!
+    updatedAt: AWSDateTime!
+    version: Int!
 
     type: PetitionType!
     status: PetitionStatus!

--- a/api/schema/petition/issue.graphql
+++ b/api/schema/petition/issue.graphql
@@ -1,6 +1,9 @@
 type IssuePetition implements Petition @aws_iam @aws_cognito_user_pools {
     PK: ID!
+
     createdAt: AWSDateTime!
+    updatedAt: AWSDateTime!
+    version: Int!
 
     type: PetitionType!
     status: PetitionStatus!

--- a/api/schema/root.graphql
+++ b/api/schema/root.graphql
@@ -8,4 +8,7 @@ type Mutation {
 
     submitCandidatePetition(data: CandidatePetitionInput!): CandidatePetition!
     @aws_cognito_user_pools(cognito_groups: ["PetitionerGroup"])
+
+    editCandidatePetition(data: EditCandidatePetitionInput!): CandidatePetition
+    @aws_cognito_user_pools(cognito_groups: ["PetitionerGroup"])
 }

--- a/api/serverless.yml
+++ b/api/serverless.yml
@@ -48,16 +48,17 @@ custom:
       - ${file(./templates/echo.yml)}
       - ${file(./templates/submitIssuePetition.yml)}
       - ${file(./templates/submitCandidatePetition.yml)}
+      - ${file(./templates/editCandidatePetition.yml)}
 
     dataSources:
       - ${file(./data/petitions.yml)}
       - ${file(./data/echo.yml)}
 
     xrayEnabled: true
-    wafConfig:
-      rules:
-        - throttle: 100
-        - disableIntrospection
+    # wafConfig:
+    #   rules:
+    #     - throttle: 100
+    #     - disableIntrospection
 
 plugins:
   - serverless-appsync-plugin

--- a/api/templates/editCandidatePetition.yml
+++ b/api/templates/editCandidatePetition.yml
@@ -1,0 +1,5 @@
+- dataSource: PetitionDataSource
+  type: Mutation
+  field: editCandidatePetition
+  request: editPetition.request.vtl
+  response: petition.response.vtl

--- a/api/templates/editPetition.request.vtl
+++ b/api/templates/editPetition.request.vtl
@@ -1,0 +1,76 @@
+#if ($context.info.fieldName == "editCandidatePetition")
+    #set($typeCheck = "CANDIDATE")
+#else
+    #set($typeCheck = "ISSUE")
+#end
+
+#set($expressionNames = {})
+#set($expressionValues = {})
+#set($expressionSet = {})
+
+#foreach ($entry in $context.arguments.data.entrySet())
+    #if ($entry.key != "PK" && $entry.key != "expectedVersion")
+        #if ((!$entry.value) && ("$!{entry.value}" == ""))
+            ## skip!
+        #else
+            $util.quiet($expressionSet.put("#${entry.key}", ":${entry.key}"))
+            $util.quiet($expressionNames.put("#${entry.key}", "$entry.key"))
+            $util.quiet($expressionValues.put(":${entry.key}", $entry.value))
+        #end
+    #end
+#end
+
+#set($expression = "")
+
+#if (!${expressionSet.isEmpty()})
+    $util.quiet($expressionSet.put("#updatedAt", ":updatedAt"))
+    $util.quiet($expressionNames.put("#updatedAt", "updatedAt"))
+    $util.quiet($expressionValues.put(":updatedAt", $util.time.nowISO8601()))
+
+	$util.quiet($expressionNames.put("#version", "version"))
+    $util.quiet($expressionValues.put(":one", 1))
+
+    #set($expression = "SET")
+    
+    #foreach ($entry in $expressionSet.entrySet())
+        #set($expression = "${expression} ${entry.key} = ${entry.value}")
+        
+        #if ($foreach.hasNext)
+            #set($expression = "${expression},")
+        #end
+    #end
+
+    #set($operation = "UpdateItem")
+#else
+    #set($operation = "GetItem")
+#end
+
+{
+    "version": "2018-05-29",
+    "operation": "$operation",
+    "key": {
+        "PK": $util.dynamodb.toDynamoDBJson($context.arguments.data.PK)
+    }
+#if ($operation == "UpdateItem")
+    ,"update": {
+        "expression": "$expression ADD #version :one",
+        "expressionNames": $util.toJson($expressionNames),
+        "expressionValues": $util.dynamodb.toMapValuesJson($expressionValues),
+    },
+    "condition": {
+        "expression": "(#owner = :owner) AND (#status = :status) AND (#version = :version) AND (#type = :type)",
+        "expressionNames": {
+            "#owner": "owner",
+            "#status": "status",
+            "#version": "version",
+            "#type": "type"
+        },
+        "expressionValues": {
+            ":owner": $util.dynamodb.toDynamoDBJson($context.identity.sub),
+            ":status": $util.dynamodb.toDynamoDBJson("NEW"),
+            ":version": $util.dynamodb.toDynamoDBJson($context.arguments.data.expectedVersion),
+            ":type": $util.dynamodb.toDynamoDBJson($typeCheck)
+        }
+    }    
+#end
+}

--- a/api/templates/petition.response.vtl
+++ b/api/templates/petition.response.vtl
@@ -1,10 +1,19 @@
-#set($type = $context.result.type)
+#if ($context.result.status == "NEW" && $context.identity.sub != $context.result.owner)
+    $util.error("You are not authorized to access this item")
+    $util.toJson({})
+#else
+    #set($type = $context.result.type)
+    
+    #if ($type == "ISSUE")
+        #set($resolvedType = "IssuePetition")
+    #elseif ($type == "CANDIDATE")
+        #set($resolvedType = "CandidatePetition")
+    #end
 
-#if ($type == "ISSUE")
-    #set($resolvedType = "IssuePetition")
-#elseif ($type == "CANDIDATE")
-    #set($resolvedType = "CandidatePetition")
+    #if (!$context.result.updatedAt)
+        $util.quiet($context.result.put("updatedAt", $context.result.createdAt))
+    #end
+
+    $util.quiet($context.result.put("__typename", $resolvedType))
+    $util.toJson($context.result)
 #end
-
-$util.quiet($context.result.put("__typename", $resolvedType))
-$util.toJson($context.result)

--- a/api/templates/submitPetition.request.vtl
+++ b/api/templates/submitPetition.request.vtl
@@ -8,7 +8,9 @@
 
 $util.quiet($data.put("type", $resolvedType))
 $util.quiet($data.put("createdAt", $util.time.nowISO8601()))
+$util.quiet($data.put("updatedAt", $data.createdAt))
 $util.quiet($data.put("owner", $context.identity.sub))
+$util.quiet($data.put("version", 1))
 
 #foreach ($entry in $context.arguments.data.entrySet())
     $util.quiet($data.put($entry.key, $entry.value))


### PR DESCRIPTION
Update the API schema to support editing Candidate petitions. Setup fields for auditing (version, updatedAt) and prevent clashes on updates. Enforce access restrictions on returned data when no updates are performed (fallback to GetItem as operation when no changes are submitted). Temporarily disable WAF on API to avoid costs while not in production.