### PR TITLE
DP-189 Add API support for editing an issue petition

### DIFF
--- a/api/schema/petition/issue.graphql
+++ b/api/schema/petition/issue.graphql
@@ -19,3 +19,12 @@ input IssuePetitionInput {
     title: String!
     detail: String!
 }
+
+input EditIssuePetitionInput {
+    PK: ID!
+
+    title: String
+    detail: String
+
+    expectedVersion: Int!
+}

--- a/api/schema/root.graphql
+++ b/api/schema/root.graphql
@@ -11,4 +11,7 @@ type Mutation {
 
     editCandidatePetition(data: EditCandidatePetitionInput!): CandidatePetition
     @aws_cognito_user_pools(cognito_groups: ["PetitionerGroup"])
+
+    editIssuePetition(data: EditIssuePetitionInput!): IssuePetition
+    @aws_cognito_user_pools(cognito_groups: ["PetitionerGroup"])
 }

--- a/api/serverless.yml
+++ b/api/serverless.yml
@@ -47,6 +47,7 @@ custom:
     mappingTemplates:
       - ${file(./templates/echo.yml)}
       - ${file(./templates/submitIssuePetition.yml)}
+      - ${file(./templates/editIssuePetition.yml)}
       - ${file(./templates/submitCandidatePetition.yml)}
       - ${file(./templates/editCandidatePetition.yml)}
 

--- a/api/templates/editIssuePetition.yml
+++ b/api/templates/editIssuePetition.yml
@@ -1,0 +1,5 @@
+- dataSource: PetitionDataSource
+  type: Mutation
+  field: editIssuePetition
+  request: editPetition.request.vtl
+  response: petition.response.vtl

--- a/api/templates/editPetition.request.vtl
+++ b/api/templates/editPetition.request.vtl
@@ -11,7 +11,7 @@
 #foreach ($entry in $context.arguments.data.entrySet())
     #if ($entry.key != "PK" && $entry.key != "expectedVersion")
         #if ((!$entry.value) && ("$!{entry.value}" == ""))
-            ## skip!
+            ## skip empty or null entries
         #else
             $util.quiet($expressionSet.put("#${entry.key}", ":${entry.key}"))
             $util.quiet($expressionNames.put("#${entry.key}", "$entry.key"))
@@ -20,15 +20,12 @@
     #end
 #end
 
-#set($expression = "")
-
 #if (!${expressionSet.isEmpty()})
+    ## build update expression
+
     $util.quiet($expressionSet.put("#updatedAt", ":updatedAt"))
     $util.quiet($expressionNames.put("#updatedAt", "updatedAt"))
     $util.quiet($expressionValues.put(":updatedAt", $util.time.nowISO8601()))
-
-	$util.quiet($expressionNames.put("#version", "version"))
-    $util.quiet($expressionValues.put(":one", 1))
 
     #set($expression = "SET")
     
@@ -41,6 +38,36 @@
     #end
 
     #set($operation = "UpdateItem")
+    #set($expression = "${expression} ADD #version :one")
+
+	$util.quiet($expressionNames.put("#version", "version"))
+    $util.quiet($expressionValues.put(":one", 1))
+
+    ## build condition check expression
+
+    #set($conditionSet = { 
+        "owner": $context.identity.sub, 
+        "version": $context.arguments.data.expectedVersion,
+        "type": $typeCheck,
+        "status": "NEW"
+    })
+
+    #set($conditionNames = {})
+    #set($conditionValues = {})
+    #set($conditionExpression = "")
+
+    #foreach ($entry in $conditionSet.entrySet())
+        #set($conditionItem = "(#${entry.key} = :${entry.key})")
+
+        #if ($conditionExpression != "")
+            #set($conditionExpression = "${conditionExpression} AND ${conditionItem}")
+        #else
+            #set($conditionExpression = "${conditionItem}")
+        #end
+
+        $util.quiet($conditionNames.put("#${entry.key}", $entry.key))
+        $util.quiet($conditionValues.put(":${entry.key}", $entry.value))
+    #end
 #else
     #set($operation = "GetItem")
 #end
@@ -53,24 +80,14 @@
     }
 #if ($operation == "UpdateItem")
     ,"update": {
-        "expression": "$expression ADD #version :one",
+        "expression": "$expression",
         "expressionNames": $util.toJson($expressionNames),
         "expressionValues": $util.dynamodb.toMapValuesJson($expressionValues),
     },
     "condition": {
-        "expression": "(#owner = :owner) AND (#status = :status) AND (#version = :version) AND (#type = :type)",
-        "expressionNames": {
-            "#owner": "owner",
-            "#status": "status",
-            "#version": "version",
-            "#type": "type"
-        },
-        "expressionValues": {
-            ":owner": $util.dynamodb.toDynamoDBJson($context.identity.sub),
-            ":status": $util.dynamodb.toDynamoDBJson("NEW"),
-            ":version": $util.dynamodb.toDynamoDBJson($context.arguments.data.expectedVersion),
-            ":type": $util.dynamodb.toDynamoDBJson($typeCheck)
-        }
+        "expression": "$conditionExpression",
+        "expressionNames": $util.toJson($conditionNames),
+        "expressionValues": $util.dynamodb.toMapValuesJson($conditionValues)
     }    
 #end
 }

--- a/api/templates/petition.response.vtl
+++ b/api/templates/petition.response.vtl
@@ -1,9 +1,10 @@
-#if ($context.result.status == "NEW" && $context.identity.sub != $context.result.owner)
-    $util.error("You are not authorized to access this item")
-    $util.toJson({})
+#if ($context.error.type == "DynamoDB:ConditionalCheckFailedException")
+	$util.error("InvalidItemCheck")
+#elseif ($context.result.status == "NEW" && $context.identity.sub != $context.result.owner)
+	$util.unauthorized()
 #else
     #set($type = $context.result.type)
-    
+
     #if ($type == "ISSUE")
         #set($resolvedType = "IssuePetition")
     #elseif ($type == "CANDIDATE")


### PR DESCRIPTION
Add required mutation definition, mapping templates and resolvers to allow the edition of a newly created, not-yet-public issue petition. Update error handling for response mapping template.