### PR TITLE
DP-186 Add API support for approving a petition

### DIFF
--- a/api/schema/petition/common.graphql
+++ b/api/schema/petition/common.graphql
@@ -78,3 +78,8 @@ input OwnedPetitionListInput {
     limit: Int
     cursor: ID
 }
+
+input ApprovePetitionInput {
+    expectedVersion: Int!
+    PK: ID!
+}

--- a/api/schema/root.graphql
+++ b/api/schema/root.graphql
@@ -19,4 +19,7 @@ type Mutation {
 
     editIssuePetition(data: EditIssuePetitionInput!): IssuePetition
     @aws_cognito_user_pools(cognito_groups: ["PetitionerGroup"])
+
+    approvePetition(data: ApprovePetitionInput!): Petition
+    @aws_cognito_user_pools(cognito_groups: ["CityStaffGroup", "AdminGroup"])
 }

--- a/api/serverless.yml
+++ b/api/serverless.yml
@@ -55,6 +55,7 @@ custom:
       - ${file(./templates/editPetition.candidate.yml)}
       - ${file(./templates/listPetition.public.yml)}
       - ${file(./templates/listPetition.byOwner.yml)}
+      - ${file(./templates/approvePetition.yml)}
 
     dataSources:
       - ${file(./data/petitions.yml)}

--- a/api/templates/approvePetition.request.vtl
+++ b/api/templates/approvePetition.request.vtl
@@ -11,7 +11,13 @@
 #set($conditionValues = {})
 
 #foreach ($entry in $conditionSet.entrySet())
-    #set($conditionItem = "(#${entry.key} = :${entry.key})")
+    #if ($entry.key == "status")
+        #set($prop = "statusCheck")
+    #else
+        #set($prop = "${entry.key}")
+    #end
+
+    #set($conditionItem = "(#${prop} = :${prop})")
 
     #if ($conditionExpression != "")
         #set($conditionExpression = "${conditionExpression} AND ${conditionItem}")
@@ -19,8 +25,8 @@
         #set($conditionExpression = "${conditionItem}")
     #end
 
-    $util.quiet($conditionNames.put("#${entry.key}", $entry.key))
-    $util.quiet($conditionValues.put(":${entry.key}", $entry.value))
+    $util.quiet($conditionNames.put("#${prop}", $entry.key))
+    $util.quiet($conditionValues.put(":${prop}", $entry.value))
 #end
 
 ## build the actual update expression
@@ -36,10 +42,16 @@
 #set($expression = "SET")
 
 #foreach ($entry in $expressionSet.entrySet())
-    #set($expression = "${expression} #${entry.key} = :${entry.key}")
+    #if ($entry.key == "status")
+        #set($prop = "statusUpdate")
+    #else
+        #set($prop = "${entry.key}")
+    #end
 
-    $util.quiet($expressionNames.put("#${entry.key}", "${entry.key}"))
-    $util.quiet($expressionValues.put(":${entry.key}", $entry.value))
+    #set($expression = "${expression} #${prop} = :${prop}")
+
+    $util.quiet($expressionNames.put("#${prop}", "${entry.key}"))
+    $util.quiet($expressionValues.put(":${prop}", $entry.value))
 
     #if ($foreach.hasNext)
         #set($expression = "${expression},")

--- a/api/templates/approvePetition.request.vtl
+++ b/api/templates/approvePetition.request.vtl
@@ -25,7 +25,11 @@
 
 ## build the actual update expression
 
-#set($expressionSet = { "updatedAt": $util.time.nowISO8601() })
+#set($expressionSet = { 
+    "updatedAt": $util.time.nowISO8601(),
+    "status": "C1"
+})
+
 #set($expressionValues = {})
 #set($expressionNames = {})
 

--- a/api/templates/approvePetition.request.vtl
+++ b/api/templates/approvePetition.request.vtl
@@ -1,0 +1,66 @@
+## build condition check
+
+#set($conditionExpression = "")
+
+#set($conditionSet = {
+    "version": $context.arguments.data.expectedVersion,
+    "status": "A1"
+})
+
+#set($conditionNames = {})
+#set($conditionValues = {})
+
+#foreach ($entry in $conditionSet.entrySet())
+    #set($conditionItem = "(#${entry.key} = :${entry.key})")
+
+    #if ($conditionExpression != "")
+        #set($conditionExpression = "${conditionExpression} AND ${conditionItem}")
+    #else
+        #set($conditionExpression = "${conditionItem}")
+    #end
+
+    $util.quiet($conditionNames.put("#${entry.key}", $entry.key))
+    $util.quiet($conditionValues.put(":${entry.key}", $entry.value))
+#end
+
+## build the actual update expression
+
+#set($expressionSet = { "updatedAt": $util.time.nowISO8601() })
+#set($expressionValues = {})
+#set($expressionNames = {})
+
+#set($expression = "SET")
+
+#foreach ($entry in $expressionSet.entrySet())
+    #set($expression = "${expression} #${entry.key} = :${entry.key}")
+
+    $util.quiet($expressionNames.put("#${entry.key}", "${entry.key}"))
+    $util.quiet($expressionValues.put(":${entry.key}", $entry.value))
+
+    #if ($foreach.hasNext)
+        #set($expression = "${expression},")
+    #end
+#end
+
+$util.quiet($expressionValues.put(":one", 1))
+$util.quiet($expressionNames.put("#version", "version"))
+
+#set($expression = "${expression} ADD #version :one")
+
+{
+    "version": "2018-05-29",
+    "operation": "UpdateItem",
+    "key": {
+        "PK": $util.dynamodb.toDynamoDBJson($context.arguments.data.PK)
+    },
+    "update": {
+        "expression": "$expression",
+        "expressionNames": $util.toJson($expressionNames),
+        "expressionValues": $util.dynamodb.toMapValuesJson($expressionValues)
+    },
+    "condition": {
+        "expression": "$conditionExpression",
+        "expressionNames": $util.toJson($conditionNames),
+        "expressionValues": $util.dynamodb.toMapValuesJson($conditionValues)
+    }
+}

--- a/api/templates/approvePetition.yml
+++ b/api/templates/approvePetition.yml
@@ -1,0 +1,5 @@
+- dataSource: PetitionDataSource
+  type: Mutation
+  field: approvePetition
+  request: approvePetition.request.vtl
+  response: petition.response.vtl

--- a/api/templates/petition.response.vtl
+++ b/api/templates/petition.response.vtl
@@ -1,8 +1,18 @@
+#set($isAuthorized = false)
+
 #if ($context.error.type == "DynamoDB:ConditionalCheckFailedException")
 	$util.error("InvalidItemCheck")
-#elseif ($context.result.status == "NEW" && $context.identity.sub != $context.result.owner)
-	$util.unauthorized()
+#elseif ($context.result.status.indexOf("A") == 0 && $context.identity.sub != $context.result.owner)
+    #foreach ($group in $context.identity.claims.get("cognito:groups"))
+        #if ($group == "CityStaffGroup" || $group == "AdminGroup")
+            #set($isAuthorized = true)
+        #end
+    #end
 #else
+    #set($isAuthorized = true)
+#end
+
+#if ($isAuthorized)
     #set($type = $context.result.type)
 
     #if ($type == "ISSUE")
@@ -29,4 +39,6 @@
     $util.quiet($context.result.put("status", $statusMap[$context.result.status]))
 
     $util.toJson($context.result)
+#else
+    $util.unauthorized()
 #end


### PR DESCRIPTION
Create a new mutation allowing admin or staff users to set an appropriate petition to the status of ACTIVE, making it publicly visible and able to receive endorsements.