### PR TITLE
DP-219 Add API support for site configuration

### DIFF
--- a/api/data/assets.yml
+++ b/api/data/assets.yml
@@ -1,4 +1,23 @@
 - type: AWS_LAMBDA
   name: AssetsDataSource
+  description: "Datasource for adding and listing configurable site resources"
   config:
     lambdaFunctionArn: ${self:custom.myAssetsLambdaArn}
+
+- type: AMAZON_DYNAMODB
+  name: AssetsConfigDataSource
+  description: "Datasource for storing site configuration, data should reference items added by using AssetsDataSource"
+  config:
+    tableName: ${self:custom.myPetitionTableName}
+    iamRoleStatements:
+      - Effect: Allow
+        Action:
+          - dynamodb:GetItem
+          - dynamodb:PutItem
+          - dynamodb:DeleteItem
+          - dynamodb:Scan
+          - dynamodb:Query
+          - dynamodb:UpdateItem
+        Resource:
+          - ${self:custom.myPetitionTableArn}
+          - { Fn::Join: ["/", ["${self:custom.myPetitionTableArn}", "*"]] }

--- a/api/data/assets.yml
+++ b/api/data/assets.yml
@@ -8,7 +8,7 @@
   name: AssetsConfigDataSource
   description: "Datasource for storing site configuration, data should reference items added by using AssetsDataSource"
   config:
-    tableName: ${self:custom.myPetitionTableName}
+    tableName: ${self:custom.mySiteConfigTableName}
     iamRoleStatements:
       - Effect: Allow
         Action:
@@ -19,5 +19,5 @@
           - dynamodb:Query
           - dynamodb:UpdateItem
         Resource:
-          - ${self:custom.myPetitionTableArn}
-          - { Fn::Join: ["/", ["${self:custom.myPetitionTableArn}", "*"]] }
+          - ${self:custom.mySiteConfigTableArn}
+          - { Fn::Join: ["/", ["${self:custom.mySiteConfigTableArn}", "*"]] }

--- a/api/data/assets.yml
+++ b/api/data/assets.yml
@@ -1,0 +1,4 @@
+- type: AWS_LAMBDA
+  name: AssetsDataSource
+  config:
+    lambdaFunctionArn: ${self:custom.myAssetsLambdaArn}

--- a/api/data/petitions.yml
+++ b/api/data/petitions.yml
@@ -1,17 +1,17 @@
-type: AMAZON_DYNAMODB
-name: PetitionDataSource
-description: "Datasource giving access to petition data, backed by a DynamoDB table"
-config:
-  tableName: ${self:custom.myPetitionTableName}
-  iamRoleStatements:
-    - Effect: Allow
-      Action:
-        - dynamodb:GetItem
-        - dynamodb:PutItem
-        - dynamodb:DeleteItem
-        - dynamodb:Scan
-        - dynamodb:Query
-        - dynamodb:UpdateItem
-      Resource:
-        - ${self:custom.myPetitionTableArn}
-        - { Fn::Join: ["/", ["${self:custom.myPetitionTableArn}", "*"]] }
+- type: AMAZON_DYNAMODB
+  name: PetitionDataSource
+  description: "Datasource giving access to petition data, backed by a DynamoDB table"
+  config:
+    tableName: ${self:custom.myPetitionTableName}
+    iamRoleStatements:
+      - Effect: Allow
+        Action:
+          - dynamodb:GetItem
+          - dynamodb:PutItem
+          - dynamodb:DeleteItem
+          - dynamodb:Scan
+          - dynamodb:Query
+          - dynamodb:UpdateItem
+        Resource:
+          - ${self:custom.myPetitionTableArn}
+          - { Fn::Join: ["/", ["${self:custom.myPetitionTableArn}", "*"]] }

--- a/api/data/signatures.yml
+++ b/api/data/signatures.yml
@@ -1,17 +1,17 @@
-type: AMAZON_DYNAMODB
-name: SignatureDataSource
-description: "Datasource giving access to signature data, backed by a DynamoDB table"
-config:
-  tableName: ${self:custom.mySignatureTableName}
-  iamRoleStatements:
-    - Effect: Allow
-      Action:
-        - dynamodb:GetItem
-        - dynamodb:PutItem
-        - dynamodb:DeleteItem
-        - dynamodb:Scan
-        - dynamodb:Query
-        - dynamodb:UpdateItem
-      Resource:
-        - ${self:custom.mySignatureTableArn}
-        - { Fn::Join: ["/", ["${self:custom.mySignatureTableArn}", "*"]] }
+- type: AMAZON_DYNAMODB
+  name: SignatureDataSource
+  description: "Datasource giving access to signature data, backed by a DynamoDB table"
+  config:
+    tableName: ${self:custom.mySignatureTableName}
+    iamRoleStatements:
+      - Effect: Allow
+        Action:
+          - dynamodb:GetItem
+          - dynamodb:PutItem
+          - dynamodb:DeleteItem
+          - dynamodb:Scan
+          - dynamodb:Query
+          - dynamodb:UpdateItem
+        Resource:
+          - ${self:custom.mySignatureTableArn}
+          - { Fn::Join: ["/", ["${self:custom.mySignatureTableArn}", "*"]] }

--- a/api/schema/root.graphql
+++ b/api/schema/root.graphql
@@ -15,6 +15,18 @@ type Query {
 
     getUsers(query: SearchUsersInput): UserConnection!
     @aws_cognito_user_pools(cognito_groups: ["AdminGroup"])
+
+    getSiteResources(query: ListResourcesInput!): ResourceConnection!
+    @aws_cognito_user_pools(cognito_groups: ["AdminGroup"])
+
+    getResourceUploadURL(query: GetResourceUploadURLInput!): String
+    @aws_cognito_user_pools(cognito_groups: ["AdminGroup"])
+
+    getResourceVersion(query: GetResourceVersionInput!): String
+    @aws_cognito_user_pools(cognito_groups: ["AdminGroup"])
+
+    siteConfiguration: SiteConfiguration!
+    @aws_iam @aws_cognito_user_pools
 }
 
 type Mutation {
@@ -44,4 +56,13 @@ type Mutation {
 
     updateUserAccess(data: UpdateUserAccessInput!): User!
     @aws_cognito_user_pools(cognito_groups: ["AdminGroup"])
+
+    updateSiteConfiguration(data: SiteConfigurationInput!): SiteConfiguration!
+    @aws_cognito_user_pools(cognito_groups: ["AdminGroup"])
+}
+
+type Subscription {
+    updatedSiteConfiguration: SiteConfiguration!
+    @aws_subscribe(mutations: ["updateSiteConfiguration"])
+    @aws_iam @aws_cognito_user_pools
 }

--- a/api/schema/root.graphql
+++ b/api/schema/root.graphql
@@ -62,7 +62,7 @@ type Mutation {
 }
 
 type Subscription {
-    updatedSiteConfiguration: SiteConfiguration!
+    updatedSiteConfiguration: SiteConfigurationSubscription
     @aws_subscribe(mutations: ["updateSiteConfiguration"])
     @aws_iam @aws_cognito_user_pools
 }

--- a/api/schema/site-manager.graphql
+++ b/api/schema/site-manager.graphql
@@ -27,9 +27,18 @@ input SiteConfigurationInput {
     buttonColor: ID
     logoImage: ID
     headerColor: ID
+    expectedVersion: Int!
 }
 
 type SiteConfiguration @aws_iam @aws_cognito_user_pools {
+    highlightColor: ID
+    buttonColor: ID
+    logoImage: ID
+    headerColor: ID
+    version: Int!
+}
+
+type SiteConfigurationSubscription @aws_iam @aws_cognito_user_pools {
     highlightColor: ID
     buttonColor: ID
     logoImage: ID

--- a/api/schema/site-manager.graphql
+++ b/api/schema/site-manager.graphql
@@ -1,0 +1,37 @@
+enum AssetType {
+    LOGO
+}
+
+input ListResourcesInput {
+    type: AssetType!
+
+    limit: Int
+    cursor: ID
+}
+
+type ResourceConnection @aws_iam @aws_cognito_user_pools {
+    items: [String!]!
+    token: ID
+}
+
+input GetResourceVersionInput {
+    type: AssetType!
+}
+
+input GetResourceUploadURLInput {
+    type: AssetType!
+}
+
+input SiteConfigurationInput {
+    highlightColor: ID
+    buttonColor: ID
+    logoImage: ID
+    headerColor: ID
+}
+
+type SiteConfiguration @aws_iam @aws_cognito_user_pools {
+    highlightColor: ID
+    buttonColor: ID
+    logoImage: ID
+    headerColor: ID
+}

--- a/api/serverless.yml
+++ b/api/serverless.yml
@@ -15,6 +15,7 @@ provider:
 
 custom:
   myUserPoolId: ${param:userPoolId, output:backend-auth.UserPoolId}
+  myAssetsBucketName: ${param:assetsBucketName, output:frontend-assets.AssetsBucketName}
 
   myPetitionTableName: ${param:petitionTableName, output:backend-data.PetitionsTableName}
   myPetitionTableArn: ${param:petitionTableArn, output:backend-data.PetitionsTableArn}
@@ -85,6 +86,7 @@ custom:
       USER_NONE: "none"
 
       COGNITO_USER_POOL: ${self:custom.myUserPoolId}
+      ASSETS_BUCKET_NAME: ${self:custom.myAssetsBucketName}
 
     mappingTemplates:
       - ${file(./templates/echo.yml)}
@@ -110,6 +112,7 @@ custom:
       - ${file(./data/signatures.yml)}
       - ${file(./data/users.yml)}
       - ${file(./data/none.yml)}
+      - ${file(./data/assets.yml)}
 
     xrayEnabled: true
     # wafConfig:

--- a/api/serverless.yml
+++ b/api/serverless.yml
@@ -108,6 +108,7 @@ custom:
       - ${file(./templates/signatures.byPetition.yml)}
       - ${file(./templates/signatures.petitionSummary.yml)}
       - ${file(./templates/admin/siteConfiguration.yml)}
+      - ${file(./templates/admin/siteConfiguration.update.yml)}
       - ${file(./templates/admin/siteResource.listByType.yml)}
       - ${file(./templates/admin/siteResource.versionByType.yml)}
       - ${file(./templates/admin/siteResource.uploadUrlByType.yml)}

--- a/api/serverless.yml
+++ b/api/serverless.yml
@@ -109,6 +109,7 @@ custom:
       - ${file(./templates/signatures.petitionSummary.yml)}
       - ${file(./templates/admin/siteConfiguration.yml)}
       - ${file(./templates/admin/siteResource.listByType.yml)}
+      - ${file(./templates/admin/siteResource.versionByType.yml)}
 
     dataSources:
       - ${file(./data/petitions.yml)}

--- a/api/serverless.yml
+++ b/api/serverless.yml
@@ -20,6 +20,7 @@ custom:
   mySignatureTableName: ${param:signatureTableName, output:backend-data.SignaturesTableName}
   mySignatureTableArn: ${param:signatureTableArn, output:backend-data.SignaturesTableArn}
   myAdminLambdaArn: ${param:adminLambdaArn, output:backend-auth.AdminLambdaArn}
+  myAssetsLambdaArn: ${param:assetsLambdaArn, output:frontend-assets.AssetsLambdaArn}
 
   esbuild:
     minify: true

--- a/api/serverless.yml
+++ b/api/serverless.yml
@@ -105,6 +105,7 @@ custom:
       - ${file(./templates/petition.byId.yml)}
       - ${file(./templates/signatures.byPetition.yml)}
       - ${file(./templates/signatures.petitionSummary.yml)}
+      - ${file(./templates/admin/siteConfiguration.yml)}
 
     dataSources:
       - ${file(./data/petitions.yml)}

--- a/api/serverless.yml
+++ b/api/serverless.yml
@@ -15,10 +15,16 @@ provider:
 
 custom:
   myUserPoolId: ${param:userPoolId, output:backend-auth.UserPoolId}
+
   myPetitionTableName: ${param:petitionTableName, output:backend-data.PetitionsTableName}
   myPetitionTableArn: ${param:petitionTableArn, output:backend-data.PetitionsTableArn}
+
   mySignatureTableName: ${param:signatureTableName, output:backend-data.SignaturesTableName}
   mySignatureTableArn: ${param:signatureTableArn, output:backend-data.SignaturesTableArn}
+
+  mySiteConfigTableName: ${param:siteConfigTableName, output:backend-data.SiteConfigTableName}
+  mySiteConfigTableArn: ${param:siteConfigTableArn, output:backend-data.SiteConfigTableArn}
+
   myAdminLambdaArn: ${param:adminLambdaArn, output:backend-auth.AdminLambdaArn}
   myAssetsLambdaArn: ${param:assetsLambdaArn, output:frontend-assets.AssetsLambdaArn}
 

--- a/api/serverless.yml
+++ b/api/serverless.yml
@@ -85,6 +85,8 @@ custom:
       USER_ADMIN: "admin"
       USER_NONE: "none"
 
+      # values to be replaced in lambda invocations
+      # that require them
       COGNITO_USER_POOL: ${self:custom.myUserPoolId}
       ASSETS_BUCKET_NAME: ${self:custom.myAssetsBucketName}
 
@@ -106,6 +108,7 @@ custom:
       - ${file(./templates/signatures.byPetition.yml)}
       - ${file(./templates/signatures.petitionSummary.yml)}
       - ${file(./templates/admin/siteConfiguration.yml)}
+      - ${file(./templates/admin/siteResource.listByType.yml)}
 
     dataSources:
       - ${file(./data/petitions.yml)}

--- a/api/serverless.yml
+++ b/api/serverless.yml
@@ -110,6 +110,7 @@ custom:
       - ${file(./templates/admin/siteConfiguration.yml)}
       - ${file(./templates/admin/siteResource.listByType.yml)}
       - ${file(./templates/admin/siteResource.versionByType.yml)}
+      - ${file(./templates/admin/siteResource.uploadUrlByType.yml)}
 
     dataSources:
       - ${file(./data/petitions.yml)}

--- a/api/templates/admin/siteConfiguration.request.vtl
+++ b/api/templates/admin/siteConfiguration.request.vtl
@@ -2,6 +2,7 @@
     "version": "2018-05-29",
     "operation": "GetItem",
     "key": {
-        "PK": $util.dynamodb.toDynamoDBJson("SITE:CONFIG")
+        "PK": $util.dynamodb.toDynamoDBJson("SITE:CONFIG"),
+        "SK": $util.dynamodb.toDynamoDBJson("MAIN")
     }
 }

--- a/api/templates/admin/siteConfiguration.request.vtl
+++ b/api/templates/admin/siteConfiguration.request.vtl
@@ -1,0 +1,7 @@
+{
+    "version": "2018-05-29",
+    "operation": "GetItem",
+    "key": {
+        "PK": $util.dynamodb.toDynamoDBJson("SITE:CONFIG")
+    }
+}

--- a/api/templates/admin/siteConfiguration.response.vtl
+++ b/api/templates/admin/siteConfiguration.response.vtl
@@ -1,0 +1,10 @@
+#set($defaultColor = "#6284FD")
+
+#set($data = {
+    "highlightColor": $util.defaultIfNull($context.result.highlightColor, $defaultColor),
+    "buttonColor": $util.defaultIfNull($context.result.buttonColor, $defaultColor),
+    "logoImage": $context.result.logoImage,
+    "headerColor": $util.defaultIfNull($context.result.headerColor, $defaultColor)
+})
+
+$util.toJson($data)

--- a/api/templates/admin/siteConfiguration.response.vtl
+++ b/api/templates/admin/siteConfiguration.response.vtl
@@ -1,10 +1,15 @@
+#if ($context.error.type == "DynamoDB:ConditionalCheckFailedException")
+    $util.error("InvalidItemCheck")
+#end
+
 #set($defaultColor = "#6284FD")
 
 #set($data = {
     "highlightColor": $util.defaultIfNull($context.result.highlightColor, $defaultColor),
     "buttonColor": $util.defaultIfNull($context.result.buttonColor, $defaultColor),
     "logoImage": $context.result.logoImage,
-    "headerColor": $util.defaultIfNull($context.result.headerColor, $defaultColor)
+    "headerColor": $util.defaultIfNull($context.result.headerColor, $defaultColor),
+    "version": $util.defaultIfNull($context.result.version, 1)
 })
 
 $util.toJson($data)

--- a/api/templates/admin/siteConfiguration.update.request.vtl
+++ b/api/templates/admin/siteConfiguration.update.request.vtl
@@ -1,0 +1,85 @@
+#set($expressionNames = {})
+#set($expressionValues = {})
+#set($expression = "SET")
+#set($colorRegExp = "#[a-fA-F0-9]{6}")
+
+#set($data = $context.arguments.data)
+#set($validRequest = false)
+
+#if ($data.expectedVersion == 1)
+    #set($operation = "PutItem")
+    #set($values = { "version": 2 })
+#end
+
+#foreach ($entry in $data.entrySet())
+    #if ($entry.key != "expectedVersion")
+        #if ($entry.key.endsWith("Color") && !$util.matches($colorRegExp, $entry.value))
+            $util.error("InvalidColorValue")
+        #end
+
+        #if ($operation == "PutItem")
+            $util.quiet($values.put($entry.key, $entry.value))
+        #else
+            #if ($expression == "SET")
+                #set($expression = "${expression} #${entry.key} = :${entry.key}")
+            #else
+                #set($expression = "${expression}, #${entry.key} = :${entry.key}")
+            #end
+
+            $util.quiet($expressionNames.put("#${entry.key}", $entry.key))
+            $util.quiet($expressionValues.put(":${entry.key}", $entry.value))
+        #end
+
+        #set($validRequest = true)
+    #elseif ($operation != "PutItem")
+        #set($conditionExpression = "#version = :version")
+        #set($conditionNames = { "#version": "version" })
+        #set($conditionValues = { ":version": $entry.value })
+    #end
+#end
+
+#if ($operation != "PutItem")
+    #if ($expression == "SET")
+        #if ($data.expectedVersion != 1)
+            $util.error("BadRequest")
+        #end
+
+        #set($operation = "GetItem")
+    #else
+        #set($operation = "UpdateItem")
+
+        $util.quiet($expressionValues.put(":one", 1))
+        $util.quiet($expressionNames.put("#version", "version"))
+
+        #set($expression = "${expression} ADD #version :one")
+    #end
+#elseif ($validRequest == false)
+    #set($operation = "GetItem")
+    $util.error("BadRequest")
+#end
+
+{
+    "version": "2018-05-29",
+    "operation": "${operation}",
+    "key": {
+        "PK": $util.dynamodb.toDynamoDBJson("SITE:CONFIG"),
+        "SK": $util.dynamodb.toDynamoDBJson("MAIN")
+    }
+#if ($operation == "PutItem")
+    ,"attributeValues": $util.dynamodb.toMapValuesJson($values),
+    "condition": {
+        "expression": "attribute_not_exists(PK)"
+    }
+#elseif ($operation == "UpdateItem")
+    ,"update": {
+        "expression": "${expression}",
+        "expressionNames": $util.toJson($expressionNames),
+        "expressionValues": $util.dynamodb.toMapValuesJson($expressionValues)
+    },
+    "condition": {
+        "expression": "${conditionExpression}",
+        "expressionNames": $util.toJson($conditionNames),
+        "expressionValues": $util.dynamodb.toMapValuesJson($conditionValues)
+    }
+#end
+}

--- a/api/templates/admin/siteConfiguration.update.yml
+++ b/api/templates/admin/siteConfiguration.update.yml
@@ -1,0 +1,5 @@
+- dataSource: AssetsConfigDataSource
+  type: Mutation
+  field: updateSiteConfiguration
+  request: admin/siteConfiguration.update.request.vtl
+  response: admin/siteConfiguration.response.vtl

--- a/api/templates/admin/siteConfiguration.yml
+++ b/api/templates/admin/siteConfiguration.yml
@@ -1,0 +1,5 @@
+- dataSource: AssetsConfigDataSource
+  type: Query
+  field: siteConfiguration
+  request: admin/siteConfiguration.request.vtl
+  response: admin/siteConfiguration.response.vtl

--- a/api/templates/admin/siteResource.listByType.request.vtl
+++ b/api/templates/admin/siteResource.listByType.request.vtl
@@ -1,0 +1,20 @@
+#set($query = $context.arguments.query)
+
+#set($assetTypeMapping = {
+    "LOGO": "site-logo"
+})
+
+#set($targetType = $assetTypeMapping.get($query.type))
+
+#set($payload = {
+    "type": "get-resource-list",
+    "limit": $util.defaultIfNull($query.limit, ${DEFAULT_PAGE_SIZE}),
+    "target": $targetType,
+    "bucketId": "${ASSETS_BUCKET_NAME}"
+})
+
+{
+    "version": "2018-05-29",
+    "operation": "Invoke",
+    "payload": $util.toJson($payload)
+}

--- a/api/templates/admin/siteResource.listByType.response.vtl
+++ b/api/templates/admin/siteResource.listByType.response.vtl
@@ -1,0 +1,1 @@
+$util.toJson($context.result)

--- a/api/templates/admin/siteResource.listByType.yml
+++ b/api/templates/admin/siteResource.listByType.yml
@@ -1,0 +1,5 @@
+- dataSource: AssetsDataSource
+  type: Query
+  field: getSiteResources
+  request: admin/siteResource.listByType.request.vtl
+  response: admin/siteResource.listByType.response.vtl

--- a/api/templates/admin/siteResource.uploadUrlByType.request.vtl
+++ b/api/templates/admin/siteResource.uploadUrlByType.request.vtl
@@ -1,0 +1,19 @@
+#set($query = $context.arguments.query)
+
+#set($assetTypeMapping = {
+    "LOGO": "site-logo"
+})
+
+#set($targetType = $assetTypeMapping.get($query.type))
+
+#set($payload = {
+    "type": "get-upload-url",
+    "target": $targetType,
+    "bucketId": "${ASSETS_BUCKET_NAME}"
+})
+
+{
+    "version": "2018-05-29",
+    "operation": "Invoke",
+    "payload": $util.toJson($payload)
+}

--- a/api/templates/admin/siteResource.uploadUrlByType.response.vtl
+++ b/api/templates/admin/siteResource.uploadUrlByType.response.vtl
@@ -1,0 +1,1 @@
+$util.toJson($context.result)

--- a/api/templates/admin/siteResource.uploadUrlByType.yml
+++ b/api/templates/admin/siteResource.uploadUrlByType.yml
@@ -1,0 +1,5 @@
+- dataSource: AssetsDataSource
+  type: Query
+  field: getResourceUploadURL
+  request: admin/siteResource.uploadUrlByType.request.vtl
+  response: admin/siteResource.uploadUrlByType.response.vtl

--- a/api/templates/admin/siteResource.versionByType.request.vtl
+++ b/api/templates/admin/siteResource.versionByType.request.vtl
@@ -1,0 +1,19 @@
+#set($query = $context.arguments.query)
+
+#set($assetTypeMapping = {
+    "LOGO": "site-logo"
+})
+
+#set($targetType = $assetTypeMapping.get($query.type))
+
+#set($payload = {
+    "type": "get-current-version",
+    "target": $targetType,
+    "bucketId": "${ASSETS_BUCKET_NAME}"
+})
+
+{
+    "version": "2018-05-29",
+    "operation": "Invoke",
+    "payload": $util.toJson($payload)
+}

--- a/api/templates/admin/siteResource.versionByType.response.vtl
+++ b/api/templates/admin/siteResource.versionByType.response.vtl
@@ -1,0 +1,1 @@
+$util.toJson($context.result)

--- a/api/templates/admin/siteResource.versionByType.yml
+++ b/api/templates/admin/siteResource.versionByType.yml
@@ -1,0 +1,5 @@
+- dataSource: AssetsDataSource
+  type: Query
+  field: getResourceVersion
+  request: admin/siteResource.versionByType.request.vtl
+  response: admin/siteResource.versionByType.response.vtl

--- a/assets/serverless.yml
+++ b/assets/serverless.yml
@@ -80,8 +80,10 @@ resources:
     assetsBucketName: { Value: "${self:custom.app.bucketName}" }
     assetsBucketId: { Value: "${self:custom.app.bucketId}" }
     assetsBucketDomain: { Value: { Fn::GetAtt: [FrontendDistBucket, RegionalDomainName] } }
+    assetsLambdaArn: { Value: { Fn::GetAtt: [ManageAssetsLambdaFunction, Arn] } }
 
 outputs:
   AssetsBucketName: ${self:custom.app.bucketName}
   AssetsBucketId: ${self:custom.app.bucketId}
   AssetsBucketDomain: { Fn::GetAtt: [FrontendDistBucket, RegionalDomainName] }
+  AssetsLambdaArn: { Fn::GetAtt: [ManageAssetsLambdaFunction, Arn] }

--- a/serverless-compose.yml
+++ b/serverless-compose.yml
@@ -14,6 +14,7 @@ services:
       siteConfigTableName: ${backend-data.siteConfigTableName}
       adminLambdaArn: ${backend-auth.adminLambdaArn}
       assetsLambdaArn: ${frontend-assets.assetsLambdaArn}
+      assetsBucketName: ${frontend-assets.assetsBucketName}
 
   backend-auth-public:
     path: auth-public

--- a/serverless-compose.yml
+++ b/serverless-compose.yml
@@ -9,6 +9,7 @@ services:
       petitionTableArn: ${backend-data.petitionTableArn}
       petitionTableName: ${backend-data.petitionTableName}
       adminLambdaArn: ${backend-auth.adminLambdaArn}
+      assetsLambdaArn: ${frontend-assets.assetsLambdaArn}
 
   backend-auth-public:
     path: auth-public

--- a/serverless-compose.yml
+++ b/serverless-compose.yml
@@ -8,6 +8,10 @@ services:
       userPoolId: ${backend-auth.userPoolId}
       petitionTableArn: ${backend-data.petitionTableArn}
       petitionTableName: ${backend-data.petitionTableName}
+      signatureTableArn: ${backend-data.signatureTableArn}
+      signatureTableName: ${backend-data.signatureTableName}
+      siteConfigTableArn: ${backend-data.siteConfigTableArn}
+      siteConfigTableName: ${backend-data.siteConfigTableName}
       adminLambdaArn: ${backend-auth.adminLambdaArn}
       assetsLambdaArn: ${frontend-assets.assetsLambdaArn}
 


### PR DESCRIPTION
Adds the ability for admin users to setup the site configuration dynamically and add new resources and assets. The site configuration can be queried and subscribed to by all users in order to immediately react to changes in the site's appearance.