### PR TITLE
Add account verification resend code feature

### DIFF
--- a/api/schema/root.graphql
+++ b/api/schema/root.graphql
@@ -66,6 +66,9 @@ type Mutation {
     updateUserAccess(data: UpdateUserAccessInput!): User!
     @aws_cognito_user_pools(cognito_groups: ["AdminGroup"])
 
+    requestUserVerificationCodeResend(email: String!): Boolean!
+    @aws_iam
+
     updateSiteConfiguration(data: SiteConfigurationInput!): SiteConfiguration!
     @aws_cognito_user_pools(cognito_groups: ["AdminGroup"])
 }

--- a/api/serverless.yml
+++ b/api/serverless.yml
@@ -15,6 +15,7 @@ provider:
 
 custom:
   myUserPoolId: ${param:userPoolId, output:backend-auth.UserPoolId}
+  myUserPoolClientId: ${param:userPoolClientId, output:backend-auth.UserPoolClientId}
   myAssetsBucketName: ${param:assetsBucketName, output:frontend-assets.AssetsBucketName}
 
   myPetitionTableName: ${param:petitionTableName, output:backend-data.PetitionsTableName}
@@ -94,6 +95,7 @@ custom:
       # values to be replaced in lambda invocations
       # that require them
       COGNITO_USER_POOL: ${self:custom.myUserPoolId}
+      COGNITO_CLIENT_ID: ${self:custom.myUserPoolClientId}
       ASSETS_BUCKET_NAME: ${self:custom.myAssetsBucketName}
 
     mappingTemplates:
@@ -121,6 +123,7 @@ custom:
       - ${file(./templates/endorse/matchVoter.yml)}
       - ${file(./templates/endorse/verifySignature.yml)}
       - ${file(./templates/endorse/submitCode.yml)}
+      - ${file(./templates/account.resendCode.yml)}
 
     functionConfigurations:
       - ${file(./templates/admin/siteConfiguration.updateValidation.yml)}

--- a/api/templates/account.resendCode.request.vtl
+++ b/api/templates/account.resendCode.request.vtl
@@ -1,0 +1,12 @@
+#set($payload = {
+    "type": "resend-code",
+    "userPoolId": "${COGNITO_USER_POOL}",
+    "email": $context.arguments.email,
+    "clientId": "${COGNITO_CLIENT_ID}"
+})
+
+{
+    "version": "2018-05-29",
+    "operation": "Invoke",
+    "payload": $util.toJson($payload)
+}

--- a/api/templates/account.resendCode.response.vtl
+++ b/api/templates/account.resendCode.response.vtl
@@ -1,0 +1,5 @@
+#if ($context.result.error != "None")
+    $util.error("We could not service this request", $context.result.error)
+#end
+
+$util.toJson(true)

--- a/api/templates/account.resendCode.yml
+++ b/api/templates/account.resendCode.yml
@@ -1,0 +1,5 @@
+- dataSource: UserDataSource
+  type: Mutation
+  field: requestUserVerificationCodeResend
+  request: account.resendCode.request.vtl
+  response: account.resendCode.response.vtl

--- a/api/templates/signatures.byPetition.request.vtl
+++ b/api/templates/signatures.byPetition.request.vtl
@@ -6,7 +6,7 @@
 
     #if (!$isAuthorized)
         #foreach ($group in $context.identity.claims.get("cognito:groups"))
-            #if ($group == "CityStaffGroup" || $group == "AdminGroup")
+            #if ($group == "CityStaffGroup" || $group == "AdminGroup" || $group == "GuestStaffGroup")
                 #set($isAuthorized = true)
             #end
         #end

--- a/auth-public/serverless.yml
+++ b/auth-public/serverless.yml
@@ -68,6 +68,7 @@ resources:
                     - { Fn::Join: ["/", ["${self:custom.myApiId}", "types/Query/fields/getVoterRecordMatch"]] }
                     - { Fn::Join: ["/", ["${self:custom.myApiId}", "types/Mutation/fields/submitSignature"]] }
                     - { Fn::Join: ["/", ["${self:custom.myApiId}", "types/Mutation/fields/submitVerificationCode"]] }
+                    - { Fn::Join: ["/", ["${self:custom.myApiId}", "types/Mutation/fields/requestUserVerificationCodeResend"]] }
                     - { Fn::Join: ["/", ["${self:custom.myApiId}", "types/Subscription/fields/updatedSiteConfiguration"]] }
                     # grant read access to petition types and common data
                     - { Fn::Join: ["/", ["${self:custom.myApiId}", "types/IssuePetition/*"]] }

--- a/auth/lambda/admin/index.ts
+++ b/auth/lambda/admin/index.ts
@@ -7,6 +7,7 @@ import { handleCreateUser } from "./user-create";
 import { handleDeleteUser } from "./user-delete";
 import { handleSelectUser } from "./user-select";
 import { handleUpdateUserAccess } from "./user-update-access";
+import { handleResendCode } from "./user-resend-code";
 
 const client = new CognitoIdentityProviderClient({});
 
@@ -23,6 +24,9 @@ export const handler: Handler<AdminLambdaEvent> = async (event): Promise<any> =>
 
         case Actions.UpdateAccess:
             return await handleUpdateUserAccess(event, client);
+
+        case Actions.ResendCode:
+            return await handleResendCode(event, client);
 
         default:
             console.log("Unsupported action requested");

--- a/auth/lambda/admin/types.ts
+++ b/auth/lambda/admin/types.ts
@@ -3,6 +3,7 @@ import type { AccessGroupKeys } from "../common";
 export type HasEmail = { email: string };
 export type HasUserPoolId = { userPoolId: string };
 export type HasUserTarget = { username: string };
+export type HasClientId = { clientId: string };
 
 export type EventCommon = HasEmail & HasUserPoolId;
 
@@ -11,7 +12,8 @@ export enum Actions {
     Create = "create-user",
     Delete = "delete-user",
     Select = "select-user",
-    UpdateAccess = "update-user-access"
+    UpdateAccess = "update-user-access",
+    ResendCode = "resend-code"
 }
 
 export type NewUserInput = {
@@ -53,8 +55,13 @@ export type SelectUserEvent = HasUserPoolId & {
     limit?: number;
 };
 
+export type ResendVerificationCodeEvent = HasUserPoolId & HasClientId & HasEmail & {
+    type: Actions.ResendCode
+}
+
 export type AdminLambdaEvent =
     | NewUserEvent
     | DeleteUserEvent
     | SelectUserEvent
-    | UpdateUserAccessEvent;
+    | UpdateUserAccessEvent
+    | ResendVerificationCodeEvent;

--- a/auth/lambda/admin/user-resend-code.ts
+++ b/auth/lambda/admin/user-resend-code.ts
@@ -1,0 +1,40 @@
+import {
+    CognitoIdentityProviderClient,
+    ListUsersCommand,
+    ResendConfirmationCodeCommand,
+    UserType
+} from "@aws-sdk/client-cognito-identity-provider";
+import type { Option, ResendVerificationCodeEvent } from "./types";
+
+export async function handleResendCode(
+    event: ResendVerificationCodeEvent,
+    client: CognitoIdentityProviderClient
+): Promise<Option<boolean>> {
+    try {
+        const listCommand = new ListUsersCommand({
+            UserPoolId: event.userPoolId,
+            Filter: `email = \"${event.email}\"`
+        });
+
+        const items: UserType[] = (await client.send(listCommand))?.Users ?? [];
+
+        if (!items.length) return { error: "NotFound" };
+
+        const target = items.find((user) =>
+            ["UNCONFIRMED", "RESET_REQUIRED"].includes(user.UserStatus ?? "")
+        );
+
+        if (!target) return { error: "NotFound" };
+
+        const resendCodeCommand = new ResendConfirmationCodeCommand({
+            ClientId: event.clientId,
+            Username: target.Username
+        });
+
+        await client.send(resendCodeCommand);
+
+        return { error: "None", data: true };
+    } catch (err) {
+        return { error: (err as Error)?.name };
+    }
+}

--- a/auth/resources/lambda-role-admin-action.yml
+++ b/auth/resources/lambda-role-admin-action.yml
@@ -46,5 +46,6 @@ Resources:
                   - cognito-idp:AdminDisableUser
                   - cognito-idp:ListUsers
                   - cognito-idp:ListGroups
+                  - cognito-idp:ResendConfirmationCode
                 Resource:
                   - { Fn::GetAtt: [CognitoUserPoolAppUserPool, Arn] }

--- a/serverless-compose.yml
+++ b/serverless-compose.yml
@@ -6,6 +6,7 @@ services:
     path: api
     params:
       userPoolId: ${backend-auth.userPoolId}
+      userPoolClientId: ${backend-auth.userPoolClientId}
       petitionTableArn: ${backend-data.petitionTableArn}
       petitionTableName: ${backend-data.petitionTableName}
       signatureTableArn: ${backend-data.signatureTableArn}


### PR DESCRIPTION
**Problem:**
A user might not be able to navigate back to the screen where they are supposed to input their account verification code, or it may expire.

**Description:**
Cognito enforces that an account must be verified before being able to request a password reset (i.e, forgot password option) and those verification codes have a 24 hour expiration period, after which the account needs to have the code sent through admin intervention.

**Solution:**
Add a new public mutation that internally has the access rights to request the code be resent, validating that the user exists in the user pool and is currently in a state requiring the code to be input.