### PR TITLE
DP-411: Return the petition information from submit code pipeline

### DIFF
--- a/api/schema/signature.graphql
+++ b/api/schema/signature.graphql
@@ -2,10 +2,10 @@ type SignatureSummary @aws_iam @aws_cognito_user_pools {
     required: Int
     verified: Int
 
-    approved: Int 
+    approved: Int
     @aws_cognito_user_pools(cognito_groups: ["AdminGroup", "CityStaffGroup", "GuestStaffGroup"])
-    
-    rejected: Int 
+
+    rejected: Int
     @aws_cognito_user_pools(cognito_groups: ["AdminGroup", "CityStaffGroup", "GuestStaffGroup"])
 
     deadline: AWSDateTime
@@ -151,6 +151,10 @@ type SignatureVerification @aws_iam {
 }
 
 type CodeSubmissionResult @aws_iam {
-    error: Boolean!
-    message: String!
+    # petition data
+    id: ID
+    title: String
+
+    # possible errors coming from the pipeline
+    error: String
 }

--- a/api/serverless.yml
+++ b/api/serverless.yml
@@ -94,6 +94,7 @@ custom:
       - ${file(./templates/endorse/verifySignature.processVerification.yml)}
       - ${file(./templates/endorse/verifySignature.storeSignature.yml)}
       - ${file(./templates/endorse/verifySignature.validatePetition.yml)}
+      - ${file(./templates/endorse/submitCode.retrievePetition.yml)}
       - ${file(./templates/endorse/submitCode.lookupSignatureId.yml)}
       - ${file(./templates/endorse/submitCode.updateSignature.yml)}
       - ${file(./templates/staff/approveOrRejectSignature.fetchSignature.yml)}

--- a/api/templates/endorse/submitCode.retrievePetition.request.vtl
+++ b/api/templates/endorse/submitCode.retrievePetition.request.vtl
@@ -1,0 +1,9 @@
+#set($PK = $context.prev.result.target)
+
+{
+    "version": "2018-05-29",
+    "operation": "GetItem",
+    "key": {
+        "PK": $util.dynamodb.toDynamoDBJson($PK)
+    }
+}

--- a/api/templates/endorse/submitCode.retrievePetition.response.vtl
+++ b/api/templates/endorse/submitCode.retrievePetition.response.vtl
@@ -1,0 +1,16 @@
+#set($petition = $context.result)
+
+#if ($petition.status != "${STATUS_ACTIVE}")
+    $util.error(
+        "This petition is either not active or does not exist",
+        "InvalidPetition"
+    )
+#else
+    #if ($petition.type == "CANDIDATE")
+        #set($context.prev.result.title = "${petition.name}")
+    #else
+        #set($context.prev.result.title = "${petition.title}")
+    #end
+
+    $util.toJson($context.prev.result)
+#end

--- a/api/templates/endorse/submitCode.retrievePetition.yml
+++ b/api/templates/endorse/submitCode.retrievePetition.yml
@@ -1,0 +1,4 @@
+- dataSource: PetitionDataSource
+  name: retrievePetition
+  request: endorse/submitCode.retrievePetition.request.vtl
+  response: endorse/submitCode.retrievePetition.response.vtl

--- a/api/templates/endorse/submitCode.updateSignature.response.vtl
+++ b/api/templates/endorse/submitCode.updateSignature.response.vtl
@@ -1,8 +1,5 @@
 #if (!$context.error && (!$context.result.cancellationReasons || $context.result.cancellationReasons.isEmpty()))
-    $util.toJson({
-        "error": false,
-        "message": "Your signature has been verified correctly"
-    })
+    $util.toJson($context.prev.result)
 #elseif ($context.error)
     $util.error(
         "We could not process your request at the moment. Please try again later",

--- a/api/templates/endorse/submitCode.yml
+++ b/api/templates/endorse/submitCode.yml
@@ -5,5 +5,6 @@
   functions:
     - lookupSignatureId
     - updateSignature
+    - retrievePetition
   request: endorse/submitCode.request.vtl
   response: endorse/submitCode.response.vtl

--- a/package.json
+++ b/package.json
@@ -1,5 +1,8 @@
 {
   "devDependencies": {
     "@serverless/compose": "^1.2.4"
+  },
+  "scripts": {
+    "serverless": "serverless"
   }
 }


### PR DESCRIPTION
# Overview

Adds a new step to the `submitCode` pipeline so the petition information is returned to the frontend via the API in the same way we return that information in the `verifySignature` pipeline.

This fixes the issue where a message is displayed to the user after submitting the code rather than the petition title.

## Frontend PR

https://github.com/maplight/Digital-Petitions/pull/273

## Task

[DP-411](https://maplight.atlassian.net/browse/DP-411)

[DP-411]: https://maplight.atlassian.net/browse/DP-411?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ